### PR TITLE
add function to calculate score

### DIFF
--- a/model/score.py
+++ b/model/score.py
@@ -1,0 +1,40 @@
+import pickle
+from train import WakatiMecab
+
+class ScoreGenerator():
+    def __init__(self, text):
+        self.text = [text]
+        self.paths = ['/code/model/tf_lgb_ill.pkl', 
+                      '/code/model/tf_lgb_mount.pkl',
+                      '/code/model/tf_lgb_ill.pkl']
+        self.models = []
+        for path in self.paths:
+            model = pickle.load(open(path, 'rb'))
+            self.models.append(model)
+
+    #与えられたテキストをベクトル化する
+    def text2vec(self, vectorizer_path='/code/model/vectorizer.pkl'):
+        wakati_mecab = WakatiMecab()
+        test_corpus = [wakati_mecab.wakati(s) for s in self.text]
+
+        vectorizer = pickle.load(open(vectorizer_path, 'rb'))
+        text_vec = vectorizer.transform(test_corpus)
+
+        return text_vec
+
+    """
+    モデルを読み込みスコアを返す関数
+    """
+    def calculate_score(self):
+        text_vec = self.text2vec()
+
+        labels = ['negative', 'mount', 'ill']
+        score_each_label = {}
+        for label, model in zip(labels, self.models):
+            predict = model.predict(text_vec)
+            
+            #クラスの分布する確率とクラスの数字の内積で連続値のスコアを計算
+            expected_score = sum([score * prob for score, prob in enumerate(predict[0])])
+            score_each_label[label] = expected_score 
+        
+        return score_each_label


### PR DESCRIPTION
## WHAT
・テキストをベクトル化する関数を実装
・モデルを読み込んでスコアを返す関数を実装

## HOW
・上記の関数をScoreGeneratorクラスとして実装(model/score.py)

## MEMO
・スコアは{"negative" : 3.0, "mount" : 2.0, "ill" : 1.0}として出力
・各スコアはクラスの分布する確率とクラスの数字の内積で計算した